### PR TITLE
reduce changes

### DIFF
--- a/common/src/main/java/com/tc/net/protocol/ClientNetworkStackHarness.java
+++ b/common/src/main/java/com/tc/net/protocol/ClientNetworkStackHarness.java
@@ -77,8 +77,8 @@ public class ClientNetworkStackHarness extends LayeredNetworkStackHarness {
     }
   }
   
-  protected ClientConnectionEstablisher createClientConnectionEstablisher() {
-    return transportFactory.createClientConnectionEstablisher();
+  protected ClientConnectionEstablisher createClientConnectionEstablisher(ClientMessageChannel clientMessaheChannel) {
+    return transportFactory.createClientConnectionEstablisher(clientMessaheChannel.getClientConnectionErrorListener());
   }
 
   protected void connectStack() {
@@ -86,7 +86,7 @@ public class ClientNetworkStackHarness extends LayeredNetworkStackHarness {
   //  connect up the channel the end of the chain
     last.setReceiveLayer(channel);
     
-    final ClientConnectionEstablisher cce = createClientConnectionEstablisher();
+    final ClientConnectionEstablisher cce = createClientConnectionEstablisher(channel);
     channel.setMessageTransportInitiator(new MessageTransportInitiator() {
       @Override
       public NetworkStackID openMessageTransport(Collection<ConnectionInfo> dest, ConnectionID connection) throws CommStackMismatchException, IOException, MaxConnectionsExceededException, TCTimeoutException {

--- a/common/src/main/java/com/tc/net/protocol/ClientNetworkStackHarness.java
+++ b/common/src/main/java/com/tc/net/protocol/ClientNetworkStackHarness.java
@@ -77,8 +77,8 @@ public class ClientNetworkStackHarness extends LayeredNetworkStackHarness {
     }
   }
   
-  protected ClientConnectionEstablisher createClientConnectionEstablisher(ClientMessageChannel clientMessaheChannel) {
-    return transportFactory.createClientConnectionEstablisher(clientMessaheChannel.getClientConnectionErrorListener());
+  protected ClientConnectionEstablisher createClientConnectionEstablisher() {
+    return transportFactory.createClientConnectionEstablisher();
   }
 
   protected void connectStack() {

--- a/common/src/main/java/com/tc/net/protocol/tcm/ClientMessageChannel.java
+++ b/common/src/main/java/com/tc/net/protocol/tcm/ClientMessageChannel.java
@@ -26,7 +26,7 @@ import com.tc.object.ClientIDProvider;
 import com.tc.object.msg.ClientHandshakeMessageFactory;
 
 
-public interface ClientMessageChannel extends MessageChannel, NetworkLayer, MessageTransportListener, ClientIDProvider {
+public interface ClientMessageChannel extends MessageChannel, NetworkLayer, MessageTransportListener, ClientIDProvider, ClientConnectionErrorListener {
 
   public int getConnectCount();
 
@@ -35,6 +35,8 @@ public interface ClientMessageChannel extends MessageChannel, NetworkLayer, Mess
   public ClientHandshakeMessageFactory getClientHandshakeMessageFactory();
 
   public void setMessageTransportInitiator(MessageTransportInitiator initiator);
-
-  public ClientConnectionErrorListener getClientConnectionErrorListener();
+  
+  public void addClientConnectionErrorListener(ClientConnectionErrorListener l);
+  
+  public void removeClientConnectionErrorListener(ClientConnectionErrorListener l);
 }

--- a/common/src/main/java/com/tc/net/protocol/tcm/ClientMessageChannel.java
+++ b/common/src/main/java/com/tc/net/protocol/tcm/ClientMessageChannel.java
@@ -19,6 +19,7 @@
 package com.tc.net.protocol.tcm;
 
 import com.tc.net.protocol.NetworkLayer;
+import com.tc.net.protocol.transport.ClientConnectionErrorListener;
 import com.tc.net.protocol.transport.MessageTransportInitiator;
 import com.tc.net.protocol.transport.MessageTransportListener;
 import com.tc.object.ClientIDProvider;
@@ -34,5 +35,6 @@ public interface ClientMessageChannel extends MessageChannel, NetworkLayer, Mess
   public ClientHandshakeMessageFactory getClientHandshakeMessageFactory();
 
   public void setMessageTransportInitiator(MessageTransportInitiator initiator);
-  
+
+  public ClientConnectionErrorListener getClientConnectionErrorListener();
 }

--- a/common/src/main/java/com/tc/net/protocol/tcm/ClientMessageChannelImpl.java
+++ b/common/src/main/java/com/tc/net/protocol/tcm/ClientMessageChannelImpl.java
@@ -29,6 +29,7 @@ import com.tc.net.StripeID;
 import com.tc.net.core.ConnectionInfo;
 import com.tc.net.protocol.NetworkStackID;
 import com.tc.net.protocol.TCNetworkMessage;
+import com.tc.net.protocol.transport.ClientConnectionErrorListener;
 import com.tc.net.protocol.transport.ConnectionID;
 import com.tc.net.protocol.transport.JvmIDUtil;
 import com.tc.net.protocol.transport.MessageTransport;
@@ -54,11 +55,14 @@ public class ClientMessageChannelImpl extends AbstractMessageChannel implements 
   private final SessionProvider           sessionProvider;
   private MessageTransportInitiator       initiator;
   private volatile SessionID              channelSessionID = SessionID.NULL_ID;
+  private final ClientConnectionErrorListener errorListener;
 
   protected ClientMessageChannelImpl(TCMessageFactory msgFactory, TCMessageRouter router,
-                                     SessionProvider sessionProvider, ProductID productId) {
+                                     SessionProvider sessionProvider, ProductID productId,
+                                     ClientConnectionErrorListener errorListener) {
     super(router, logger, msgFactory, StripeID.NULL_ID, productId);
     this.sessionProvider = sessionProvider;
+    this.errorListener = errorListener;
     this.sessionProvider.initProvider();
   }
 
@@ -189,5 +193,10 @@ public class ClientMessageChannelImpl extends AbstractMessageChannel implements 
     if (index < 0) { throw new RuntimeException("unexpected format: " + vmName); }
 
     return Integer.parseInt(vmName.substring(0, index));
+  }
+
+  @Override
+  public ClientConnectionErrorListener getClientConnectionErrorListener() {
+    return this.errorListener;
   }
 }

--- a/common/src/main/java/com/tc/net/protocol/tcm/CommunicationsManager.java
+++ b/common/src/main/java/com/tc/net/protocol/tcm/CommunicationsManager.java
@@ -54,9 +54,6 @@ public interface CommunicationsManager extends PrettyPrintable {
    */
 
   public ClientMessageChannel createClientChannel(ProductID product, SessionProvider provider, int timeout);
-    
-  public ClientMessageChannel createClientChannel(ProductID product, SessionProvider provider, int timeout,
-                                                  ClientConnectionErrorListener errorListener);
 
   public NetworkListener createListener(TCSocketAddress addr, boolean transportDisconnectRemovesChannel,
                                         ConnectionIDFactory connectionIdFactory);

--- a/common/src/main/java/com/tc/net/protocol/tcm/CommunicationsManager.java
+++ b/common/src/main/java/com/tc/net/protocol/tcm/CommunicationsManager.java
@@ -20,6 +20,7 @@ package com.tc.net.protocol.tcm;
 
 import com.tc.net.TCSocketAddress;
 import com.tc.net.core.TCConnectionManager;
+import com.tc.net.protocol.transport.ClientConnectionErrorListener;
 import com.tc.net.protocol.transport.ConnectionIDFactory;
 import com.tc.object.session.SessionProvider;
 import com.tc.operatorevent.NodeNameProvider;
@@ -54,7 +55,10 @@ public interface CommunicationsManager extends PrettyPrintable {
 
   public ClientMessageChannel createClientChannel(ProductID product, SessionProvider provider, int timeout);
     
-  public NetworkListener createListener(TCSocketAddress addr, boolean transportDisconnectRemovesChannel, 
+  public ClientMessageChannel createClientChannel(ProductID product, SessionProvider provider, int timeout,
+                                                  ClientConnectionErrorListener errorListener);
+
+  public NetworkListener createListener(TCSocketAddress addr, boolean transportDisconnectRemovesChannel,
                                         ConnectionIDFactory connectionIdFactory);
 
   public NetworkListener createListener(TCSocketAddress addr, boolean transportDisconnectRemovesChannel, 

--- a/common/src/main/java/com/tc/net/protocol/tcm/CommunicationsManagerImpl.java
+++ b/common/src/main/java/com/tc/net/protocol/tcm/CommunicationsManagerImpl.java
@@ -34,7 +34,6 @@ import com.tc.net.core.TCConnectionManagerImpl;
 import com.tc.net.core.TCListener;
 import com.tc.net.protocol.NetworkStackHarness;
 import com.tc.net.protocol.NetworkStackHarnessFactory;
-import com.tc.net.protocol.transport.ClientConnectionErrorListener;
 import com.tc.net.protocol.transport.ClientConnectionEstablisher;
 import com.tc.net.protocol.transport.ClientMessageTransport;
 import com.tc.net.protocol.transport.ConnectionHealthChecker;
@@ -264,20 +263,13 @@ public class CommunicationsManagerImpl implements CommunicationsManager {
 
   @Override
   public ClientMessageChannel createClientChannel(ProductID productId, SessionProvider sessions, int timeout) {
-    return createClientChannel(productId, sessions, timeout, null, null,null);
-  }
-
-  @Override
-  public ClientMessageChannel createClientChannel(ProductID productId, SessionProvider sessions, int timeout,
-                                                  ClientConnectionErrorListener errorListener) {
-    return createClientChannel(productId, sessions, timeout, null, null, errorListener);
+    return createClientChannel(productId, sessions, timeout, null, null);
   }
   
   public ClientMessageChannel createClientChannel(ProductID productId, SessionProvider sessions, 
                                                   int timeout, 
                                                   MessageTransportFactory transportFactory,
-                                                  TCMessageFactory messageFactory,
-                                                  ClientConnectionErrorListener errorListener) {
+                                                  TCMessageFactory messageFactory) {
 
     final TCMessageFactory msgFactory;
 
@@ -295,7 +287,7 @@ public class CommunicationsManagerImpl implements CommunicationsManager {
       msgFactory = messageFactory;
     }
 
-    ClientMessageChannelImpl rv = new ClientMessageChannelImpl(msgFactory, this.messageRouter, sessions, productId, errorListener);
+    ClientMessageChannelImpl rv = new ClientMessageChannelImpl(msgFactory, this.messageRouter, sessions, productId);
     if (transportFactory == null) transportFactory = new MessageTransportFactoryImpl(transportMessageFactory,
                                                                                      connectionHealthChecker,
                                                                                      connectionManager,
@@ -369,11 +361,6 @@ public class CommunicationsManagerImpl implements CommunicationsManager {
                                  WireProtocolMessageSink wireProtocolMessageSink) throws IOException {
 
     MessageTransportFactory transportFactory = new MessageTransportFactory() {
-      @Override
-      public ClientConnectionEstablisher createClientConnectionEstablisher(ClientConnectionErrorListener errorListener) {
-        throw new AssertionError();
-      }
-
       @Override
       public ClientConnectionEstablisher createClientConnectionEstablisher() {
         throw new AssertionError();

--- a/common/src/main/java/com/tc/net/protocol/tcm/MessageTransportFactoryImpl.java
+++ b/common/src/main/java/com/tc/net/protocol/tcm/MessageTransportFactoryImpl.java
@@ -20,6 +20,7 @@ package com.tc.net.protocol.tcm;
 
 import com.tc.net.core.TCConnection;
 import com.tc.net.core.TCConnectionManager;
+import com.tc.net.protocol.transport.ClientConnectionErrorListener;
 import com.tc.net.protocol.transport.ClientConnectionEstablisher;
 import com.tc.net.protocol.transport.ClientMessageTransport;
 import com.tc.net.protocol.transport.ConnectionHealthChecker;
@@ -71,6 +72,13 @@ public class MessageTransportFactoryImpl implements MessageTransportFactory {
                                                               new WireProtocolAdaptorFactoryImpl(), callbackport);
     cmt.addTransportListener(connectionHealthChecker);
     return cmt;
+  }
+
+  @Override
+  public ClientConnectionEstablisher createClientConnectionEstablisher(ClientConnectionErrorListener errorListener) {
+    ClientConnectionEstablisher clientConnectionEstablisher = new ClientConnectionEstablisher(reconnectionRejectedHandler
+        , errorListener);
+    return clientConnectionEstablisher;
   }
 
   protected ClientMessageTransport createClientMessageTransport(TransportHandshakeErrorHandler handshakeErrorHandler,

--- a/common/src/main/java/com/tc/net/protocol/tcm/MessageTransportFactoryImpl.java
+++ b/common/src/main/java/com/tc/net/protocol/tcm/MessageTransportFactoryImpl.java
@@ -73,14 +73,7 @@ public class MessageTransportFactoryImpl implements MessageTransportFactory {
     cmt.addTransportListener(connectionHealthChecker);
     return cmt;
   }
-
-  @Override
-  public ClientConnectionEstablisher createClientConnectionEstablisher(ClientConnectionErrorListener errorListener) {
-    ClientConnectionEstablisher clientConnectionEstablisher = new ClientConnectionEstablisher(reconnectionRejectedHandler
-        , errorListener);
-    return clientConnectionEstablisher;
-  }
-
+  
   protected ClientMessageTransport createClientMessageTransport(TransportHandshakeErrorHandler handshakeErrorHandler,
                                                                 TransportHandshakeMessageFactory messageFactory,
                                                                 WireProtocolAdaptorFactory wireProtocolAdaptorFactory,

--- a/common/src/main/java/com/tc/net/protocol/transport/ClientConnectionErrorDetails.java
+++ b/common/src/main/java/com/tc/net/protocol/transport/ClientConnectionErrorDetails.java
@@ -1,0 +1,44 @@
+package com.tc.net.protocol.transport;
+
+import com.tc.net.core.ConnectionInfo;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+public class ClientConnectionErrorDetails implements ClientConnectionErrorListener{
+
+  private final ConcurrentHashMap<ConnectionInfo, ConcurrentLinkedQueue<Exception>> exceptionMap
+      = new ConcurrentHashMap<>();
+
+  @Override
+  public void onError(ConnectionInfo connInfo, Exception e) {
+    ConcurrentLinkedQueue<Exception> exceptionList = exceptionMap.get(connInfo);
+    if(exceptionList == null){
+      exceptionList = new ConcurrentLinkedQueue<>();
+      exceptionMap.put(connInfo, exceptionList);
+    }
+    exceptionList.add(e);
+  }
+
+  public Map<String, List<Exception>> getErrors() {
+    Map<String, List<Exception>> errorMessagesMap = new HashMap<>();
+    if (exceptionMap != null) {
+      for (Map.Entry<ConnectionInfo, ConcurrentLinkedQueue<Exception>> entry : exceptionMap.entrySet()) {
+        ConnectionInfo connInfo = entry.getKey();
+        ConcurrentLinkedQueue<Exception> exceptionList = entry.getValue();
+        Object[] errorObjects = exceptionList.toArray();
+        List<Exception> errorMessages = new ArrayList<>();
+        for (Object errorObj : errorObjects) {
+          Exception e = (Exception) errorObj;
+          errorMessages.add(e);
+        }
+        errorMessagesMap.put(connInfo.toString(), errorMessages);
+      }
+    }
+    return errorMessagesMap;
+  }
+}

--- a/common/src/main/java/com/tc/net/protocol/transport/ClientConnectionErrorListener.java
+++ b/common/src/main/java/com/tc/net/protocol/transport/ClientConnectionErrorListener.java
@@ -1,0 +1,16 @@
+package com.tc.net.protocol.transport;
+
+import com.tc.net.core.ConnectionInfo;
+
+/**
+ * Any class implementing this interface can take appropriate action
+ * when a connection is not successfully established between client and server
+ *
+ * An instance of this interface can be passed to transport (lower) layer and on getting
+ * an exception, onError can be invoked to store the exception against the
+ * connection information. Stored exceptions can be passed to upper layer for inspection
+ * and analysis.
+ */
+public interface ClientConnectionErrorListener {
+  void onError(ConnectionInfo connInfo, Exception e);
+}

--- a/common/src/main/java/com/tc/net/protocol/transport/ClientMessageTransport.java
+++ b/common/src/main/java/com/tc/net/protocol/transport/ClientMessageTransport.java
@@ -323,7 +323,8 @@ public class ClientMessageTransport extends MessageTransportBase {
     } catch (InterruptedException e) {
       throw new TransportHandshakeException(e);
     } catch (TCExceptionResultException e) {
-      throw new TransportHandshakeException(e);
+      throw new TransportHandshakeException("Client was able to establish connection with server but handshake " +
+          "with server failed.", e);
     }
   }
 

--- a/common/src/main/java/com/tc/net/protocol/transport/MessageTransportFactory.java
+++ b/common/src/main/java/com/tc/net/protocol/transport/MessageTransportFactory.java
@@ -25,6 +25,8 @@ import java.util.List;
 public interface MessageTransportFactory {
   ClientConnectionEstablisher createClientConnectionEstablisher();
 
+  ClientConnectionEstablisher createClientConnectionEstablisher(ClientConnectionErrorListener errorListener);
+
   ClientMessageTransport createNewTransport();
 
   ServerMessageTransport createNewTransport(TransportHandshakeErrorHandler handler,

--- a/common/src/main/java/com/tc/net/protocol/transport/MessageTransportFactory.java
+++ b/common/src/main/java/com/tc/net/protocol/transport/MessageTransportFactory.java
@@ -25,8 +25,6 @@ import java.util.List;
 public interface MessageTransportFactory {
   ClientConnectionEstablisher createClientConnectionEstablisher();
 
-  ClientConnectionEstablisher createClientConnectionEstablisher(ClientConnectionErrorListener errorListener);
-
   ClientMessageTransport createNewTransport();
 
   ServerMessageTransport createNewTransport(TransportHandshakeErrorHandler handler,

--- a/common/src/main/java/com/tc/net/protocol/transport/TransportHandshakeException.java
+++ b/common/src/main/java/com/tc/net/protocol/transport/TransportHandshakeException.java
@@ -32,4 +32,8 @@ public class TransportHandshakeException extends IOException {
   TransportHandshakeException(Exception parent) {
     super(parent);
   }
+
+  TransportHandshakeException(String message, Exception parent) {
+    super(message, parent);
+  }
 }

--- a/common/src/main/java/com/tc/util/concurrent/TCFuture.java
+++ b/common/src/main/java/com/tc/util/concurrent/TCFuture.java
@@ -73,7 +73,7 @@ public class TCFuture {
    * @return the value set in this future (which may be null)
    * @throws InterruptedException if the current thread is interrupted while waiting for the result to be set
    * @throws TCTimeoutException if timeout period expires
-   * @throws TCExceptionResultExecption if another thread sets the future result to an exception.
+   * @throws TCExceptionResultException if another thread sets the future result to an exception.
    * @see setException(Throwable t)
    */
   public Object get(long timeout) throws InterruptedException, TCTimeoutException, TCExceptionResultException {
@@ -90,27 +90,36 @@ public class TCFuture {
    * @return the value set in this future (which may be null)
    * @throws InterruptedException if the current thread is interrupted while waiting for the result to be set
    * @throws TCTimeoutException if timeout period expires
-   * @throws TCExceptionResultExecption if another thread sets the future result to an exception.
+   * @throws TCExceptionResultException if another thread sets the future result to an exception.
    * @see setException(Throwable t)
    */
   public Object get(long timeout, boolean flagIfTimedOut) throws InterruptedException, TCTimeoutException,
       TCExceptionResultException {
     synchronized (this.lock) {
       if (cancel) { throw new InterruptedException("Future already cancelled"); }
-
+      long internalTimeout = timeout;
       while (!set) {
-        if (timeout < 0) { throw new TCTimeoutException("Timeout of " + timeout + " milliseconds occurred"); }
-
-        lock.wait(timeout);
-
-        if (cancel) { throw new InterruptedException("Future was cancelled while waiting"); }
-
-        if ((!set) && (timeout != 0)) {
+        if (internalTimeout < 0 ) {
           this.timedOut = flagIfTimedOut;
-          throw new TCTimeoutException("Timeout of " + timeout + " milliseconds occured");
+          throw new TCTimeoutException("Timeout of " + timeout + " milliseconds occurred");
+        }
+        long startTime = System.currentTimeMillis();
+        lock.wait(internalTimeout);
+        long waitTime = System.currentTimeMillis() - startTime;
+        if (cancel) { throw new InterruptedException("Future was cancelled while waiting"); }
+        if(timeout != 0L){
+          //In case the timeout value is greater than zero, then only reduce the wait time.
+          //If timeout == 0, thread waits indefinitely (Always internalTimeout == timeout == 0L)
+          internalTimeout -= waitTime;
+          if(internalTimeout==0L){
+            //If internalTimeout value has become zero, that means, total time the thread has waited
+            //is exactly equals to the timeout value passed in the invocation.In that case, reduce it by
+            //one so that client gets TCTimeoutException instead of going into indefinite wait call
+            //in next iteration
+            internalTimeout--;
+          }
         }
       }
-
       if (exception == null) {
         return value;
       } else if (exception != null) {

--- a/common/src/test/java/com/tc/net/AddressCheckerTest.java
+++ b/common/src/test/java/com/tc/net/AddressCheckerTest.java
@@ -26,7 +26,7 @@ public class AddressCheckerTest extends TestCase {
 
   public void test() throws Exception {
     AddressChecker ac = new AddressChecker();
-
+    System.out.println(InetAddress.getLocalHost());
     assertTrue(ac.isLegalBindAddress(InetAddress.getByName("127.0.0.1")));
     assertTrue(ac.isLegalBindAddress(InetAddress.getByName("0.0.0.0")));
     assertTrue(ac.isLegalBindAddress(InetAddress.getLocalHost()));

--- a/common/src/test/java/com/tc/net/protocol/transport/ClientConnectionErrorDetailsTest.java
+++ b/common/src/test/java/com/tc/net/protocol/transport/ClientConnectionErrorDetailsTest.java
@@ -1,0 +1,70 @@
+package com.tc.net.protocol.transport;
+
+import com.tc.net.core.ConnectionInfo;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static com.tc.util.Assert.assertEquals;
+import static com.tc.util.Assert.assertNotNull;
+import static com.tc.util.Assert.assertTrue;
+
+public class ClientConnectionErrorDetailsTest {
+
+  @Test
+  public void testOnError(){
+    ClientConnectionErrorDetails errorDetails = new ClientConnectionErrorDetails();
+    ConnectionInfo connInfo = new ConnectionInfo("localhost",9510);
+    Exception exception1 = new IOException("Test Exception1");
+    errorDetails.onError(connInfo, exception1);
+    Exception exception2 = new IOException("Test Exception2");
+    errorDetails.onError(connInfo, exception2);
+
+    Map<String, List<Exception>> retMap = errorDetails.getErrors();
+    retMap.get(connInfo);
+    assertNotNull(retMap);
+    assertEquals(1,retMap.size());
+    List<Exception> errorList = retMap.get(connInfo.toString());
+    assertEquals(2,errorList.size());
+    assertTrue(errorList.contains(exception1));
+    assertTrue(errorList.contains(exception2));
+  }
+
+  @Test
+  public void testGetErrorWithNoError(){
+    ClientConnectionErrorDetails errorDetails = new ClientConnectionErrorDetails();
+    Map<String, List<Exception>> retMap = errorDetails.getErrors();
+    assertNotNull(retMap);
+    assertTrue(retMap.isEmpty());
+  }
+
+  @Test
+  public void testGetError(){
+    ClientConnectionErrorDetails errorDetails = new ClientConnectionErrorDetails();
+    ConnectionInfo connInfo1 = new ConnectionInfo("localhost",9510);
+    Exception exception1 = new IOException("Test Exception1");
+    errorDetails.onError(connInfo1, exception1);
+    Exception exception2 = new IOException("Test Exception2");
+    errorDetails.onError(connInfo1, exception2);
+
+    ConnectionInfo connInfo2 = new ConnectionInfo("localhost",9710);
+    Exception exception3 = new IOException("Test Exception3");
+    errorDetails.onError(connInfo2, exception3);
+
+    Map<String, List<Exception>> retMap = errorDetails.getErrors();
+    assertNotNull(retMap);
+    assertEquals(2, retMap.size());
+    List<Exception> exceptionList1 = retMap.get(connInfo1.toString());
+
+    assertEquals(2,exceptionList1.size());
+    assertTrue(exceptionList1.contains(exception1));
+    assertTrue(exceptionList1.contains(exception2));
+
+    List<Exception> exceptionList2 = retMap.get(connInfo2.toString());
+
+    assertEquals(1,exceptionList2.size());
+    assertTrue(exceptionList2.contains(exception3));
+  }
+}

--- a/common/src/test/java/com/tc/net/protocol/transport/ClientConnectionEstablisherTest.java
+++ b/common/src/test/java/com/tc/net/protocol/transport/ClientConnectionEstablisherTest.java
@@ -71,7 +71,8 @@ public class ClientConnectionEstablisherTest {
   private TCConnection                        tcConnection;
   @Mock
   private TCSocketAddress                     sa;
-
+  @Mock
+  private ClientConnectionErrorListener       errorListener;
   @Mock
   private ConnectionIdLogger                  logger;
   @Mock
@@ -127,9 +128,9 @@ public class ClientConnectionEstablisherTest {
   public void test_open_fails_when_asyncReconnecting_is_true() throws TCTimeoutException, IOException,
       MaxConnectionsExceededException, CommStackMismatchException {
     connEstablisher.setAsyncReconnectingForTests(true);
-    Mockito.doReturn(null).when(spyConnEstablisher).connectTryAllOnce(cmt);
+    Mockito.doReturn(null).when(spyConnEstablisher).connectTryAllOnce(cmt, errorListener);
     try {
-      spyConnEstablisher.open(Collections.singleton(connInfo), cmt);
+      spyConnEstablisher.open(Collections.singleton(connInfo), cmt, errorListener);
       Assert.fail();
     } catch (TCAssertionError e) {
       // ignore
@@ -139,20 +140,20 @@ public class ClientConnectionEstablisherTest {
   @Test
   public void test_open_sets_allowReconnects_to_true() throws TCTimeoutException, IOException,
       MaxConnectionsExceededException, CommStackMismatchException {
-    Mockito.doReturn(null).when(spyConnEstablisher).connectTryAllOnce(cmt);
+    Mockito.doReturn(null).when(spyConnEstablisher).connectTryAllOnce(cmt, errorListener);
     Mockito.doReturn(tcConnection).when(connManager).createConnection((TCProtocolAdaptor) Matchers.any());
 
     spyConnEstablisher.setAllowReconnects(false);
-    spyConnEstablisher.open(Collections.singleton(connInfo), cmt);
+    spyConnEstablisher.open(Collections.singleton(connInfo), cmt, errorListener);
     Assert.assertTrue(spyConnEstablisher.getAllowReconnects());
   }
 
   @Test
   public void test_open_calls_connectTryAllOnce() throws TCTimeoutException, IOException,
       MaxConnectionsExceededException, CommStackMismatchException {
-    Mockito.doReturn(null).when(spyConnEstablisher).connectTryAllOnce(cmt);
-    spyConnEstablisher.open(Collections.singleton(connInfo), cmt);
-    Mockito.verify(spyConnEstablisher, Mockito.times(1)).connectTryAllOnce(cmt);
+    Mockito.doReturn(null).when(spyConnEstablisher).connectTryAllOnce(cmt, errorListener);
+    spyConnEstablisher.open(Collections.singleton(connInfo), cmt, errorListener);
+    Mockito.verify(spyConnEstablisher, Mockito.times(1)).connectTryAllOnce(cmt, errorListener);
   }
 
   @Test
@@ -161,7 +162,7 @@ public class ClientConnectionEstablisherTest {
     Mockito.doReturn(tcConnection).when(connManager).createConnection((TCProtocolAdaptor) Matchers.any());
     // test
     try {
-      spyConnEstablisher.open(Collections.singleton(connInfo), cmt);
+      spyConnEstablisher.open(Collections.singleton(connInfo), cmt, errorListener);
     } catch (Exception e) {
       e.printStackTrace();
       throw e;
@@ -174,7 +175,7 @@ public class ClientConnectionEstablisherTest {
   public void test_connect_tries_to_make_new_connection_and_connect() throws Exception {
     Mockito.doNothing().when(cmt).fireTransportConnectAttemptEvent();
     Mockito.doReturn(tcConnection).when(connManager).createConnection((TCProtocolAdaptor) Matchers.any());
-    spyConnEstablisher.open(Arrays.asList(connInfo), cmt);
+    spyConnEstablisher.open(Arrays.asList(connInfo), cmt, errorListener);
     Mockito.verify(cmt).open(Matchers.any(ConnectionInfo.class));
   }
 
@@ -191,8 +192,8 @@ public class ClientConnectionEstablisherTest {
   public void test_reconnect_calls_connect() throws Exception {
     Mockito.doReturn(logger).when(cmt).getLogger();
     Mockito.doReturn(tcConnection).when(connManager).createConnection((TCProtocolAdaptor) Matchers.any());
-    Mockito.doReturn(null).when(spyConnEstablisher).connectTryAllOnce(Matchers.any(ClientMessageTransport.class));
-    spyConnEstablisher.open(Arrays.asList(connInfo), cmt);
+    Mockito.doReturn(null).when(spyConnEstablisher).connectTryAllOnce(Matchers.any(ClientMessageTransport.class), Matchers.any(ClientConnectionErrorListener.class));
+    spyConnEstablisher.open(Arrays.asList(connInfo), cmt, errorListener);
     spyConnEstablisher.reconnect(cmt);
     Mockito.verify(cmt).reopen(Matchers.any(ConnectionInfo.class));
   }
@@ -200,8 +201,8 @@ public class ClientConnectionEstablisherTest {
   @Test
   public void test_restore_calls_connect() throws Exception {
     Mockito.doReturn(tcConnection).when(connManager).createConnection((TCProtocolAdaptor) Matchers.any());
-    Mockito.doReturn(null).when(spyConnEstablisher).connectTryAllOnce(Matchers.any(ClientMessageTransport.class));
-    spyConnEstablisher.open(Arrays.asList(connInfo), cmt);
+    Mockito.doReturn(null).when(spyConnEstablisher).connectTryAllOnce(Matchers.any(ClientMessageTransport.class), Matchers.any(ClientConnectionErrorListener.class));
+    spyConnEstablisher.open(Arrays.asList(connInfo), cmt, errorListener);
     spyConnEstablisher.restoreConnection(cmt, sa, 10 * 1000, callback);
     Mockito.verify(cmt).reconnect(Matchers.any(TCSocketAddress.class));
   }
@@ -222,7 +223,7 @@ public class ClientConnectionEstablisherTest {
 
   @Test
   public void test_client_keeps_trying_for_reconnect_after_unknownHostException() throws Exception {
-    spyConnEstablisher.open(Collections.singleton(connInfo), cmt);
+    spyConnEstablisher.open(Collections.singleton(connInfo), cmt, errorListener);
     Mockito.doThrow(new UnknownHostException("Host can not be resolved!")).when(spyConnEstablisher)
         .getHostByName(connInfo);
     Mockito.doReturn(tcConnection).when(connManager).createConnection((TCProtocolAdaptor) Matchers.any());

--- a/connection-loader/src/main/java/com/terracotta/connection/ClientConnectionException.java
+++ b/connection-loader/src/main/java/com/terracotta/connection/ClientConnectionException.java
@@ -1,0 +1,9 @@
+package com.terracotta.connection;
+
+public class ClientConnectionException extends RuntimeException{
+  private static final long serialVersionUID = 1L;
+
+  ClientConnectionException(String message){
+    super(message);
+  }
+}

--- a/connection-loader/src/main/java/com/terracotta/connection/TerracottaInternalClient.java
+++ b/connection-loader/src/main/java/com/terracotta/connection/TerracottaInternalClient.java
@@ -20,6 +20,9 @@ package com.terracotta.connection;
 
 import com.tc.config.schema.setup.ConfigurationSetupException;
 import com.tc.object.ClientEntityManager;
+
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeoutException;
 
 
@@ -50,4 +53,6 @@ public interface TerracottaInternalClient {
    * @return The client entity manager for end-points managed by this client.
    */
   ClientEntityManager getClientEntityManager();
+
+  Map<String, List<Exception>> getInternalConnectionErrorsPostInit();
 }

--- a/connection-loader/src/main/java/com/terracotta/connection/TerracottaInternalClientImpl.java
+++ b/connection-loader/src/main/java/com/terracotta/connection/TerracottaInternalClientImpl.java
@@ -25,6 +25,7 @@ import com.tc.object.ClientEntityManager;
 import com.tc.object.DistributedObjectClient;
 import com.tc.object.DistributedObjectClientFactory;
 import com.tc.net.protocol.transport.ClientConnectionErrorDetails;
+import com.tc.object.ClientBuilder;
 import com.terracotta.connection.client.TerracottaClientStripeConnectionConfig;
 
 import java.util.List;
@@ -54,9 +55,11 @@ public class TerracottaInternalClientImpl implements TerracottaInternalClient {
   }
   
   private DistributedObjectClientFactory buildClientCreator(TerracottaClientStripeConnectionConfig stripeConnectionConfig, Properties props, ClientConnectionErrorListener errorListener) {
+    ClientBuilder builder = ClientBuilderFactory.get().create(props);
+    builder.setClientConnectionErrorListener(errorListener);
     return new DistributedObjectClientFactory(stripeConnectionConfig.getStripeMemberUris(),
-                                              ClientBuilderFactory.get().create(props),
-                                              props, errorListener);
+                                              builder,
+                                              props);
   }
 
   @Override

--- a/connection-loader/src/main/java/com/terracotta/connection/api/AbstractConnectionService.java
+++ b/connection-loader/src/main/java/com/terracotta/connection/api/AbstractConnectionService.java
@@ -16,7 +16,6 @@ import java.net.InetSocketAddress;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.Collection;
 import java.util.Properties;
 
 abstract class AbstractConnectionService implements ConnectionService {
@@ -79,7 +78,7 @@ abstract class AbstractConnectionService implements ConnectionService {
     try {
       client.init();
     } catch (Exception e) {
-      throw new ConnectionException(e);
+      throw new DetailedConnectionException(e, client.getInternalConnectionErrorsPostInit());
     }
     return new TerracottaConnection(client.getClientEntityManager(), endpointConnector, client::shutdown);
   }

--- a/connection-loader/src/main/java/com/terracotta/connection/api/DetailedConnectionException.java
+++ b/connection-loader/src/main/java/com/terracotta/connection/api/DetailedConnectionException.java
@@ -1,0 +1,33 @@
+package com.terracotta.connection.api;
+
+import org.terracotta.connection.ConnectionException;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/*
+  Should this class be going to connection-api project?
+   */
+public class DetailedConnectionException extends ConnectionException{
+
+  /**
+   * This type can only be created as a high-level wrapper over the underlying cause.
+   *
+   * @param cause The underlying throwable
+   * @param errorMap is the map of a host:port combination and list of all the communication errors for this host:port combination
+   */
+
+  private final Map<String, List<Exception>> connectionErrorMap;
+  public DetailedConnectionException(Throwable cause, Map<String, List<Exception>> errorMap) {
+    super(cause);
+    this.connectionErrorMap = errorMap;
+  }
+
+  public Map<String, List<Exception>> getConnectionErrorMap(){
+    if(this.connectionErrorMap == null){
+      return null;
+    }
+    return Collections.unmodifiableMap(connectionErrorMap);
+  }
+}

--- a/connection-loader/src/test/java/com/terracotta/connection/api/DetailedConnectionExceptionTest.java
+++ b/connection-loader/src/test/java/com/terracotta/connection/api/DetailedConnectionExceptionTest.java
@@ -1,0 +1,45 @@
+package com.terracotta.connection.api;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+
+public class DetailedConnectionExceptionTest {
+
+  @Test
+  public void testGetConnectionErrorMapWithNullMap(){
+    Exception exc = mock(Exception.class);
+    DetailedConnectionException connException = new DetailedConnectionException(exc, null);
+    Map<String, List<Exception>> exceptionMap = connException.getConnectionErrorMap();
+    assertNull(exceptionMap);
+  }
+
+  @Test
+  public void testGetConnectionErrorMap(){
+    Exception thrownException = mock(Exception.class);
+    String endoint = "localhost:9510";
+    Exception e1 = new IOException("first exception");
+    Exception e2 = new IOException("second exception");
+    List<Exception> errorList = new ArrayList<>();
+    errorList.add(e1);
+    errorList.add(e2);
+    Map<String, List<Exception>> errorMap = new HashMap<>();
+    errorMap.put(endoint, errorList);
+    DetailedConnectionException connException = new DetailedConnectionException(thrownException, errorMap);
+    Map<String, List<Exception>> exceptionMap = connException.getConnectionErrorMap();
+    assertNotNull(exceptionMap);
+    assertEquals(1, exceptionMap.size());
+    List<Exception> retExceptions = exceptionMap.get(endoint);
+    assertNotNull(retExceptions);
+    assertEquals(2,retExceptions.size());
+    assertTrue(retExceptions.contains(e1));
+    assertTrue(retExceptions.contains(e2));
+  }
+}

--- a/dso-l1/src/main/java/com/tc/client/ClientFactory.java
+++ b/dso-l1/src/main/java/com/tc/client/ClientFactory.java
@@ -19,6 +19,7 @@
 package com.tc.client;
 
 import com.tc.lang.TCThreadGroup;
+import com.tc.net.protocol.transport.ClientConnectionErrorListener;
 import com.tc.object.ClientBuilder;
 import com.tc.object.DistributedObjectClient;
 import com.tc.object.config.ClientConfig;
@@ -36,5 +37,14 @@ public class ClientFactory {
     return new DistributedObjectClient(config, builder, threadGroup, connectionComponents,
         cluster,
         uuid, name);
+  }
+
+  public static DistributedObjectClient createClient(ClientConfig config, ClientBuilder builder, TCThreadGroup threadGroup,
+                                                     PreparedComponentsFromL2Connection connectionComponents,
+                                                     ClusterInternal cluster,
+                                                     String uuid, String name, ClientConnectionErrorListener errorListener) {
+    return new DistributedObjectClient(config, builder, threadGroup, connectionComponents,
+        cluster,
+        uuid, name, errorListener);
   }
 }

--- a/dso-l1/src/main/java/com/tc/client/ClientFactory.java
+++ b/dso-l1/src/main/java/com/tc/client/ClientFactory.java
@@ -38,13 +38,4 @@ public class ClientFactory {
         cluster,
         uuid, name);
   }
-
-  public static DistributedObjectClient createClient(ClientConfig config, ClientBuilder builder, TCThreadGroup threadGroup,
-                                                     PreparedComponentsFromL2Connection connectionComponents,
-                                                     ClusterInternal cluster,
-                                                     String uuid, String name, ClientConnectionErrorListener errorListener) {
-    return new DistributedObjectClient(config, builder, threadGroup, connectionComponents,
-        cluster,
-        uuid, name, errorListener);
-  }
 }

--- a/dso-l1/src/main/java/com/tc/object/ClientBuilder.java
+++ b/dso-l1/src/main/java/com/tc/object/ClientBuilder.java
@@ -18,6 +18,7 @@
  */
 package com.tc.object;
 
+import com.tc.net.protocol.transport.ClientConnectionErrorListener;
 import org.slf4j.Logger;
 
 import com.tc.async.api.StageManager;
@@ -46,6 +47,11 @@ public interface ClientBuilder {
   ClientMessageChannel createClientMessageChannel(CommunicationsManager commMgr,
                                                      SessionProvider sessionProvider,
                                                      int socketConnectTimeout, TCClient client);
+
+  ClientMessageChannel createClientMessageChannel(CommunicationsManager commMgr,
+                                                  SessionProvider sessionProvider,
+                                                  int socketConnectTimeout, TCClient client,
+                                                  ClientConnectionErrorListener errorListener);
 
   CommunicationsManager createCommunicationsManager(MessageMonitor monitor,
                                                     TCMessageRouter messageRouter,

--- a/dso-l1/src/main/java/com/tc/object/ClientBuilder.java
+++ b/dso-l1/src/main/java/com/tc/object/ClientBuilder.java
@@ -18,12 +18,10 @@
  */
 package com.tc.object;
 
-import com.tc.net.protocol.transport.ClientConnectionErrorListener;
 import org.slf4j.Logger;
 
 import com.tc.async.api.StageManager;
 import com.tc.management.TCClient;
-import com.tc.net.core.BufferManagerFactory;
 import com.tc.net.protocol.NetworkStackHarnessFactory;
 import com.tc.net.protocol.tcm.ClientMessageChannel;
 import com.tc.net.protocol.tcm.CommunicationsManager;
@@ -39,6 +37,7 @@ import com.tc.object.msg.ClientHandshakeMessageFactory;
 import com.tc.object.session.SessionManager;
 import com.tc.object.session.SessionProvider;
 import com.tc.cluster.ClusterInternalEventsGun;
+import com.tc.net.protocol.transport.ClientConnectionErrorListener;
 
 import java.util.Map;
 
@@ -47,11 +46,6 @@ public interface ClientBuilder {
   ClientMessageChannel createClientMessageChannel(CommunicationsManager commMgr,
                                                      SessionProvider sessionProvider,
                                                      int socketConnectTimeout, TCClient client);
-
-  ClientMessageChannel createClientMessageChannel(CommunicationsManager commMgr,
-                                                  SessionProvider sessionProvider,
-                                                  int socketConnectTimeout, TCClient client,
-                                                  ClientConnectionErrorListener errorListener);
 
   CommunicationsManager createCommunicationsManager(MessageMonitor monitor,
                                                     TCMessageRouter messageRouter,
@@ -71,5 +65,7 @@ public interface ClientBuilder {
                                                       ClientEntityManager entity);
 
   ClientEntityManager createClientEntityManager(ClientMessageChannel channel, StageManager stages);
+  
+  void setClientConnectionErrorListener(ClientConnectionErrorListener listener);
 
 }

--- a/dso-l1/src/main/java/com/tc/object/DistributedObjectClient.java
+++ b/dso-l1/src/main/java/com/tc/object/DistributedObjectClient.java
@@ -61,7 +61,6 @@ import com.tc.net.protocol.tcm.TCMessage;
 import com.tc.net.protocol.tcm.TCMessageRouter;
 import com.tc.net.protocol.tcm.TCMessageRouterImpl;
 import com.tc.net.protocol.tcm.TCMessageType;
-import com.tc.net.protocol.transport.ClientConnectionErrorListener;
 import com.tc.net.protocol.transport.HealthCheckerConfig;
 import com.tc.net.protocol.transport.HealthCheckerConfigClientImpl;
 import com.tc.net.protocol.transport.NullConnectionPolicy;
@@ -158,8 +157,6 @@ public class DistributedObjectClient implements TCClient {
   private ClientEntityManager clientEntityManager;
   private final StageManager communicationStageManager;
 
-  private final ClientConnectionErrorListener clientConnectionErrorListener;
-
 
   public DistributedObjectClient(ClientConfig config, TCThreadGroup threadGroup,
                                  PreparedComponentsFromL2Connection connectionComponents,
@@ -172,14 +169,6 @@ public class DistributedObjectClient implements TCClient {
                                  PreparedComponentsFromL2Connection connectionComponents,
                                  ClusterInternal cluster,
                                  String uuid, String name) {
-    this(config, builder, threadGroup, connectionComponents, cluster,
-        uuid, name,null);
-  }
-
-  public DistributedObjectClient(ClientConfig config, ClientBuilder builder, TCThreadGroup threadGroup,
-                                 PreparedComponentsFromL2Connection connectionComponents,
-                                 ClusterInternal cluster,
-                                 String uuid, String name, ClientConnectionErrorListener errorListener) {
     Assert.assertNotNull(config);
     this.config = config;
     this.connectionComponents = connectionComponents;
@@ -194,7 +183,6 @@ public class DistributedObjectClient implements TCClient {
     // We need a StageManager to create the SEDA stages used for handling the messages.
     final SEDA<Void> seda = new SEDA<Void>(threadGroup);
     communicationStageManager = seda.getStageManager();
-    this.clientConnectionErrorListener = errorListener;
   }
 
   private ReconnectConfig getReconnectPropertiesFromServer() {
@@ -291,7 +279,7 @@ public class DistributedObjectClient implements TCClient {
     if (socketConnectTimeout < 0) { throw new IllegalArgumentException("invalid socket time value: "
                                                                        + socketConnectTimeout); }
     this.channel = this.clientBuilder.createClientMessageChannel(this.communicationsManager,
-                                                                 sessionManager, socketConnectTimeout, this, this.clientConnectionErrorListener);
+                                                                 sessionManager, socketConnectTimeout, this);
     // add this listener so that the whole system is shutdown
     // if the transport is closed from underneath.
     //  this typically happens when the transport is disconnected and 

--- a/dso-l1/src/main/java/com/tc/object/DistributedObjectClientFactory.java
+++ b/dso-l1/src/main/java/com/tc/object/DistributedObjectClientFactory.java
@@ -46,14 +46,12 @@ public class DistributedObjectClientFactory {
   private final List<InetSocketAddress> stripeMemberUris;
   private final ClientBuilder builder;
   private final Properties        properties;
-  private final ClientConnectionErrorListener errorListener;
 
   public DistributedObjectClientFactory(List<InetSocketAddress> stripeMemberUris, ClientBuilder builder,
-                                        Properties properties, ClientConnectionErrorListener errorListener) {
+                                        Properties properties) {
     this.stripeMemberUris = stripeMemberUris;
     this.builder = builder;
     this.properties = properties;
-    this.errorListener = errorListener;
   }
 
   public DistributedObjectClient create() throws InterruptedException, ConfigurationSetupException {
@@ -92,8 +90,7 @@ public class DistributedObjectClientFactory {
     
     DistributedObjectClient client = ClientFactory.createClient(configHelper, builder, group, connectionComponents, cluster,
         uuid,
-        name,
-        this.errorListener);
+        name);
 
     try {
       client.start();

--- a/dso-l1/src/main/java/com/tc/object/DistributedObjectClientFactory.java
+++ b/dso-l1/src/main/java/com/tc/object/DistributedObjectClientFactory.java
@@ -25,6 +25,7 @@ import com.tc.config.schema.setup.ConfigurationSetupException;
 import com.tc.config.schema.setup.L1ConfigurationSetupManager;
 import com.tc.lang.L1ThrowableHandler;
 import com.tc.lang.TCThreadGroup;
+import com.tc.net.protocol.transport.ClientConnectionErrorListener;
 import com.tc.object.config.ClientConfig;
 import com.tc.object.config.ClientConfigImpl;
 import com.tc.object.config.PreparedComponentsFromL2Connection;
@@ -45,12 +46,14 @@ public class DistributedObjectClientFactory {
   private final List<InetSocketAddress> stripeMemberUris;
   private final ClientBuilder builder;
   private final Properties        properties;
+  private final ClientConnectionErrorListener errorListener;
 
   public DistributedObjectClientFactory(List<InetSocketAddress> stripeMemberUris, ClientBuilder builder,
-                                        Properties properties) {
+                                        Properties properties, ClientConnectionErrorListener errorListener) {
     this.stripeMemberUris = stripeMemberUris;
     this.builder = builder;
     this.properties = properties;
+    this.errorListener = errorListener;
   }
 
   public DistributedObjectClient create() throws InterruptedException, ConfigurationSetupException {
@@ -89,7 +92,8 @@ public class DistributedObjectClientFactory {
     
     DistributedObjectClient client = ClientFactory.createClient(configHelper, builder, group, connectionComponents, cluster,
         uuid,
-        name);
+        name,
+        this.errorListener);
 
     try {
       client.start();

--- a/dso-l1/src/main/java/com/tc/object/StandardClientBuilder.java
+++ b/dso-l1/src/main/java/com/tc/object/StandardClientBuilder.java
@@ -18,6 +18,7 @@
  */
 package com.tc.object;
 
+import com.tc.net.protocol.transport.*;
 import org.slf4j.Logger;
 import org.terracotta.connection.ConnectionPropertyNames;
 
@@ -34,10 +35,6 @@ import com.tc.net.protocol.tcm.MessageMonitor;
 import com.tc.net.protocol.tcm.TCMessage;
 import com.tc.net.protocol.tcm.TCMessageRouter;
 import com.tc.net.protocol.tcm.TCMessageType;
-import com.tc.net.protocol.transport.ConnectionPolicy;
-import com.tc.net.protocol.transport.HealthCheckerConfig;
-import com.tc.net.protocol.transport.ReconnectionRejectedHandler;
-import com.tc.net.protocol.transport.TransportHandshakeErrorHandlerForL1;
 import com.tc.object.handshakemanager.ClientHandshakeManager;
 import com.tc.object.handshakemanager.ClientHandshakeManagerImpl;
 import com.tc.object.msg.ClientHandshakeMessageFactory;
@@ -62,6 +59,11 @@ public class StandardClientBuilder implements ClientBuilder {
                                                          SessionProvider sessionProvider, 
                                                          int socketConnectTimeout, TCClient client) {
     return commMgr.createClientChannel(typeOfClient, sessionProvider, socketConnectTimeout);
+  }
+
+  @Override
+  public ClientMessageChannel createClientMessageChannel(CommunicationsManager commMgr, SessionProvider sessionProvider, int socketConnectTimeout, TCClient client, ClientConnectionErrorListener errorListener) {
+    return commMgr.createClientChannel(typeOfClient, sessionProvider, socketConnectTimeout, errorListener);
   }
 
   @Override

--- a/dso-l1/src/main/java/com/tc/object/StandardClientBuilder.java
+++ b/dso-l1/src/main/java/com/tc/object/StandardClientBuilder.java
@@ -49,6 +49,7 @@ import java.util.Properties;
 public class StandardClientBuilder implements ClientBuilder {
   
   private final ProductID typeOfClient;
+  private ClientConnectionErrorListener listener;
 
   public StandardClientBuilder(Properties connectionProperties) {
     this.typeOfClient = getTypeOfClient(connectionProperties);
@@ -58,12 +59,11 @@ public class StandardClientBuilder implements ClientBuilder {
   public ClientMessageChannel createClientMessageChannel(CommunicationsManager commMgr,
                                                          SessionProvider sessionProvider, 
                                                          int socketConnectTimeout, TCClient client) {
-    return commMgr.createClientChannel(typeOfClient, sessionProvider, socketConnectTimeout);
-  }
-
-  @Override
-  public ClientMessageChannel createClientMessageChannel(CommunicationsManager commMgr, SessionProvider sessionProvider, int socketConnectTimeout, TCClient client, ClientConnectionErrorListener errorListener) {
-    return commMgr.createClientChannel(typeOfClient, sessionProvider, socketConnectTimeout, errorListener);
+    ClientMessageChannel cmc = commMgr.createClientChannel(typeOfClient, sessionProvider, socketConnectTimeout);
+    if (listener != null) {
+      cmc.addClientConnectionErrorListener(listener);
+    }
+    return cmc;
   }
 
   @Override
@@ -114,5 +114,10 @@ public class StandardClientBuilder implements ClientBuilder {
 
   protected BufferManagerFactory getBufferManagerFactory() {
     return new ClearTextBufferManagerFactory();
+  }
+
+  @Override
+  public void setClientConnectionErrorListener(ClientConnectionErrorListener listener) {
+    this.listener = listener;
   }
 }

--- a/dso-l1/src/test/java/com/tc/object/DistributedObjectClientTest.java
+++ b/dso-l1/src/test/java/com/tc/object/DistributedObjectClientTest.java
@@ -174,7 +174,7 @@ public class DistributedObjectClientTest extends TestCase {
     connectionProperties.put(ConnectionPropertyNames.CONNECTION_TYPE, ProductID.PERMANENT);
     ClientBuilder builder = new StandardClientBuilder(connectionProperties) {
       @Override
-      public ClientMessageChannel createClientMessageChannel(CommunicationsManager commMgr, SessionProvider sessionProvider, int socketConnectTimeout, TCClient client, ClientConnectionErrorListener errorListener) {
+      public ClientMessageChannel createClientMessageChannel(CommunicationsManager commMgr, SessionProvider sessionProvider, int socketConnectTimeout, TCClient client) {
         ClientMessageChannel channel = Mockito.mock(ClientMessageChannel.class);
         try {
           Mockito.when(channel.open(Mockito.anyCollection())).thenThrow(new RuntimeException("bad connection"));
@@ -186,7 +186,7 @@ public class DistributedObjectClientTest extends TestCase {
       }
     };
     
-    DistributedObjectClient client = new DistributedObjectClient(new ClientConfigImpl(manager), builder, threadGroup, l2connection, cluster, null, null, errorListener);
+    DistributedObjectClient client = new DistributedObjectClient(new ClientConfigImpl(manager), builder, threadGroup, l2connection, cluster, null, null);
     client.start();
     Assert.assertTrue(threadGroup.activeCount() > 0);
     long start = System.currentTimeMillis();

--- a/dso-l1/src/test/java/com/tc/object/DistributedObjectClientTest.java
+++ b/dso-l1/src/test/java/com/tc/object/DistributedObjectClientTest.java
@@ -28,6 +28,7 @@ import com.tc.management.TCClient;
 import com.tc.net.core.ConnectionInfo;
 import com.tc.net.protocol.tcm.ClientMessageChannel;
 import com.tc.net.protocol.tcm.CommunicationsManager;
+import com.tc.net.protocol.transport.ClientConnectionErrorListener;
 import com.tc.object.config.ClientConfigImpl;
 import com.tc.object.config.ConnectionInfoConfig;
 import com.tc.object.config.PreparedComponentsFromL2Connection;
@@ -120,6 +121,12 @@ public class DistributedObjectClientTest extends TestCase {
   }
   
   public void testFatalError() throws Exception {
+    ClientConnectionErrorListener errorListener = new ClientConnectionErrorListener() {
+      @Override
+      public void onError(ConnectionInfo connInfo, Exception e) {
+
+      }
+    };
     L1ConfigurationSetupManager manager = new L1ConfigurationSetupManager() {
       @Override
       public String[] processArguments() {
@@ -167,7 +174,7 @@ public class DistributedObjectClientTest extends TestCase {
     connectionProperties.put(ConnectionPropertyNames.CONNECTION_TYPE, ProductID.PERMANENT);
     ClientBuilder builder = new StandardClientBuilder(connectionProperties) {
       @Override
-      public ClientMessageChannel createClientMessageChannel(CommunicationsManager commMgr, SessionProvider sessionProvider, int socketConnectTimeout, TCClient client) {
+      public ClientMessageChannel createClientMessageChannel(CommunicationsManager commMgr, SessionProvider sessionProvider, int socketConnectTimeout, TCClient client, ClientConnectionErrorListener errorListener) {
         ClientMessageChannel channel = Mockito.mock(ClientMessageChannel.class);
         try {
           Mockito.when(channel.open(Mockito.anyCollection())).thenThrow(new RuntimeException("bad connection"));
@@ -179,7 +186,7 @@ public class DistributedObjectClientTest extends TestCase {
       }
     };
     
-    DistributedObjectClient client = new DistributedObjectClient(new ClientConfigImpl(manager), builder, threadGroup, l2connection, cluster, null, null);
+    DistributedObjectClient client = new DistributedObjectClient(new ClientConfigImpl(manager), builder, threadGroup, l2connection, cluster, null, null, errorListener);
     client.start();
     Assert.assertTrue(threadGroup.activeCount() > 0);
     long start = System.currentTimeMillis();

--- a/dso-l2/src/test/java/com/tc/net/protocol/tcm/TestCommunicationsManager.java
+++ b/dso-l2/src/test/java/com/tc/net/protocol/tcm/TestCommunicationsManager.java
@@ -53,12 +53,6 @@ public class TestCommunicationsManager implements CommunicationsManager {
   }
 
   @Override
-  public ClientMessageChannel createClientChannel(ProductID product, SessionProvider provider, int timeout
-      , ClientConnectionErrorListener errorListener){
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
   public NetworkListener createListener(TCSocketAddress addr, boolean transportDisconnectRemovesChannel, ConnectionIDFactory connectionIdFactory) {
     throw new UnsupportedOperationException(); 
   }

--- a/dso-l2/src/test/java/com/tc/net/protocol/tcm/TestCommunicationsManager.java
+++ b/dso-l2/src/test/java/com/tc/net/protocol/tcm/TestCommunicationsManager.java
@@ -20,6 +20,7 @@ package com.tc.net.protocol.tcm;
 
 import com.tc.net.TCSocketAddress;
 import com.tc.net.core.TCConnectionManager;
+import com.tc.net.protocol.transport.ClientConnectionErrorListener;
 import com.tc.net.protocol.transport.ConnectionIDFactory;
 import com.tc.object.session.SessionProvider;
 import com.tc.operatorevent.NodeNameProvider;
@@ -49,6 +50,12 @@ public class TestCommunicationsManager implements CommunicationsManager {
   @Override
   public ClientMessageChannel createClientChannel(ProductID product, SessionProvider provider, int timeout) {
     throw new UnsupportedOperationException(); 
+  }
+
+  @Override
+  public ClientMessageChannel createClientChannel(ProductID product, SessionProvider provider, int timeout
+      , ClientConnectionErrorListener errorListener){
+    throw new UnsupportedOperationException();
   }
 
   @Override


### PR DESCRIPTION
Please see changes.  I am trying to reduce the number of call sites and signatures changed but only adding knowledge of the new listener in TerracottaInternalClient, StandardClientBuilder, ClientMessageChannel, and ClientConnectionEstablisher.  By having the ClientBuilder as the main insertion point, we skip many of the builders and constructors along the way.  Also, this is better because any extension of StandardClientBuilder can shim the error reporter and change/add information as needed. 